### PR TITLE
Upgrader configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Change Log
 ----------
 
 
-0.6.0
+0.5.1
 =====
 
 * Limit upgrader config scan to its file only

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Change Log
 ----------
 
 
+0.4.1
+=====
+
+* Limit upgrader config scan to its file only
+
+
 0.4.0
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded-core"
-version = "0.5.0"
+version = "0.5.1"
 description = "Core data models for Park Lab ENCODE based projects"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded-core"
-version = "0.4.0"
+version = "0.4.1"
 description = "Core data models for Park Lab ENCODE based projects"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded-core"
-version = "0.4.1"
+version = "0.4.1.0b0"
 description = "Core data models for Park Lab ENCODE based projects"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded_core/__init__.py
+++ b/src/encoded_core/__init__.py
@@ -11,11 +11,6 @@ from .local_roles import LocalRolesAuthorizationPolicy
 APP_VERSION_REGISTRY_KEY = 'encoded-core.app_version'
 
 
-def includeme(config):
-    """include me method."""
-    config.scan()
-
-
 def app_version(config):
     if not config.registry.settings.get(APP_VERSION_REGISTRY_KEY):
         # we update version as part of deployment process `deploy_beanstalk.py`
@@ -64,6 +59,7 @@ def main(global_config, **local_config):
         config.include('snovault.root')
 
     config.include('.upgrade')
+    config.scan()
 
     app = config.make_wsgi_app()
     return app

--- a/src/encoded_core/upgrade.py
+++ b/src/encoded_core/upgrade.py
@@ -9,7 +9,7 @@ LATE = 10
 
 
 def includeme(config):
-    config.scan()
+    config.scan(__name__)  # Only scan this file, not entire project!
 
     def callback():
         """ add_upgrade for all item types

--- a/src/encoded_core/upgrade.py
+++ b/src/encoded_core/upgrade.py
@@ -5,11 +5,17 @@ from snovault import (
 )
 from snovault.upgrader import default_upgrade_finalizer
 
+
 LATE = 10
 
 
 def includeme(config):
-    config.scan(__name__)  # Only scan this file, not entire project!
+    """Configure upgrade actions and finalizers.
+
+    Scan only the file, not the entire project, to avoid adding other
+    features to the configuration that may conflict with parent app.
+    """
+    config.scan(__name__)
 
     def callback():
         """ add_upgrade for all item types


### PR DESCRIPTION
Limit the configuration scan in the upgrade module to prevent conflicts on use in the parent app. Moved to project's `__init__.py` to enable configuration for tests.