### PR TITLE
GA4 Updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded-core"
-version = "0.6.0"
+version = "0.6.0.2b1"  # TODO: To become 0.7.0
 description = "Core data models for Park Lab ENCODE based projects"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded-core"
-version = "0.6.0.2b1"  # TODO: To become 0.7.0
+version = "0.6.0.2b2"  # TODO: To become 0.7.0
 description = "Core data models for Park Lab ENCODE based projects"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded_core/file_views.py
+++ b/src/encoded_core/file_views.py
@@ -334,7 +334,7 @@ def update_google_analytics(context, request, ga_config, filename, file_size_dow
 
     file_extension =  os.path.splitext(filename)[1][1:]
     item_types = [ty for ty in reversed(context.jsonld_type()[:-1])]
-    lab_or_submission_center_title = lab_or_submission_center.get("display_title") if lab_or_submission_center is not None or "None"
+    lab_or_submission_center_title = lab_or_submission_center.get("display_title") if lab_or_submission_center is not None else "None"
 
     ga_payload = {
         "client_id": ga_cid,


### PR DESCRIPTION
[GA4 Measurement Protocol ](https://developers.google.com/analytics/devguides/collection/protocol/ga4?hl=en) integration added to collect server-side download metrics into GA4 property.

Latest beta release (0.6.0.2b2): https://pypi.org/project/encoded-core/0.6.0.2b2/
The branch to test: https://github.com/smaht-dac/smaht-portal/tree/ui-dev4

TODO: Currently, SMaHT counterpart of 4DN's `experiment_type` dimension is missing, will be available soon.