### PR TITLE
Updated the temporary AWS session token policy (related to rclone/smaht-submitr).

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,8 @@ Change Log
 
 * 2024-05-01/dmichaels
 * Updated the temporary AWS session token policy, for AWS file uploads, in types.external_creds
-  to allow s3:HeadObject for the bucket/key, and to allow s3:ListBucket and s3:ListBucketVersions
-  for the bucket itself. This was to support rclone hashsum md5 for smaht-submitr.
+  to allow s3:HeadObject for the bucket/key, and to allow s3:ListBucket for the bucket itself.
+  This was to support rclone hashsum md5 for smaht-submitr.
 
 
 0.8.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Change Log
   to allow s3:HeadObject for the bucket/key, and to allow s3:ListBucket for the bucket itself.
   This supports rclone hashsum md5 for smaht-submitr; specifically to check if a file which is
   already in AWS S3 is the same (according to the md5) as a corresponding file in Google Cloud Storage.
+  Yes it does seem odd having to enable s3:ListBucket to get the checksum of a specific object;
+  but this was what was empirically determined what was needed by rclone. 
 
 
 0.8.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ Change Log
 ----------
 
 
+0.8.4
+=====
+
+* 2024-05-01/dmichaels
+* Updated the temporary AWS session token policy, for AWS file uploads, in types.external_creds
+  to allow s3:HeadObject for the bucket/key, and to allow s3:ListBucket and s3:ListBucketVersions
+  for the bucket itself. This was to support rclone hashsum md5 for smaht-submitr.
+
+
 0.8.3
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,8 @@ Change Log
 * 2024-05-01/dmichaels
 * Updated the temporary AWS session token policy, for AWS file uploads, in types.external_creds
   to allow s3:HeadObject for the bucket/key, and to allow s3:ListBucket for the bucket itself.
-  This was to support rclone hashsum md5 for smaht-submitr.
+  This supports rclone hashsum md5 for smaht-submitr; specifically to check if a file which is
+  already in AWS S3 is the same (according to the md5) as a corresponding file in Google Cloud Storage.
 
 
 0.8.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded-core"
-version = "0.8.3"
+version = "0.8.3.1b1"  # TODO: To become 0.8.4
 description = "Core data models for Park Lab ENCODE based projects"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded_core/types/file.py
+++ b/src/encoded_core/types/file.py
@@ -89,10 +89,20 @@ def external_creds(bucket, key, name=None, profile_name=None):
                 {
                     "Action": [
                         "s3:PutObject",
-                        "s3:GetObject"
+                        "s3:GetObject",
+                        "s3:HeadObject"
                     ],
                     "Resource": [
                         f"arn:aws:s3:::{bucket}/{key}"
+                    ],
+                    "Effect": "Allow"
+                },
+                {
+                    "Action": [
+                        "s3:ListBucket"
+                    ],
+                    "Resource": [
+                        f"arn:aws:s3:::{bucket}"
                     ],
                     "Effect": "Allow"
                 }


### PR DESCRIPTION
* Updated the temporary AWS session token policy, for AWS file uploads, in types.external_creds
  to allow s3:HeadObject for the bucket/key, and to allow s3:ListBucket for the bucket itself.
  This was to support rclone hashsum md5 for smaht-submitr.

* CANCELLING THIS PR ... Because it turns out that using rclone hashsum md5 for AWS S3 is unreliable anyways - for larger files - will have smaht-submitr use boto3 to do this which does not require these changes.
