### PR TITLE
GA4 Server Side Downloading Updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ encoded-core
 Change Log
 ----------
 
+0.9.1
+=====
+
+* set default GA4 client_id for non browser requests
+* get assay type from data_generation_summary for GA4
+
+
 0.9.0
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded-core"
-version = "0.9.0"
+version = "0.9.1"
 description = "Core data models for Park Lab ENCODE based projects"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded_core/file_views.py
+++ b/src/encoded_core/file_views.py
@@ -357,17 +357,16 @@ def get_submitter_title(request, context, properties):
 
 
 def get_experiment_or_assay_type(request, context, properties):
+    file_item = get_item_or_none(request, context.uuid)
+    if file_item is None:
+        return None
     # SMaHT
-    if properties.get('file_sets') is not None:
-        if len(properties.get('file_sets')) > 0:
-            file_set = get_item_or_none(request, properties.get('file_sets')[0], 'file-sets', frame='embedded')
-            if file_set is not None and file_set.get('assay'):
-                return file_set['assay'].get('display_title')
+    if file_item.get('data_generation_summary') and file_item['data_generation_summary'].get('assays'):
+        assays = file_item['data_generation_summary']['assays']
+        return assays[0] if len(assays) > 0 else None
     # 4DN
-    elif properties.get('track_and_facet_info') is None:
-        file_item = get_item_or_none(request, context.uuid)
-        if file_item is not None and file_item.get('track_and_facet_info') and file_item['track_and_facet_info'].get('experiment_type'):
-            return file_item['track_and_facet_info']['experiment_type']
+    elif file_item.get('track_and_facet_info') and file_item['track_and_facet_info'].get('experiment_type'):
+        return file_item['track_and_facet_info']['experiment_type']
     # fallback
     return None
 
@@ -395,6 +394,8 @@ def update_google_analytics(context, request, ga_config, filename, file_size_dow
         ga_cid = request.cookies.get("_ga")
         if ga_cid:
             ga_cid = ".".join(ga_cid.split(".")[2:])
+        else:
+            ga_cid = "programmatic"
 
     ga_tid_mapping = ga_config["hostnameTrackerIDMapping"].get(request.host,
                                                        ga_config["hostnameTrackerIDMapping"].get("default"))


### PR DESCRIPTION
- Non-browser requests (e.g. via `curl`) fail to track the server-side downloading since `client_id`, which was stored in the cookie, was missing. A default value ("programmatic") is set for this.
- Function that grabs assay type from File item is updated  

