### PR TITLE
Refactor: Replaces 'get_federation_token' with 'assume_role' in 'external_creds()' for IAM Role-based S3 credential generation

### DIFF
--- a/src/encoded_core/tests/test_assume_role_migration.py
+++ b/src/encoded_core/tests/test_assume_role_migration.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Standalone test for the assume_role migration in external_creds().
+Run with:  python test_assume_role_migration.py
+"""
+import boto3, json, os, sys
+ 
+ROLE_ARN    = os.environ['S3_UPLOAD_ROLE_ARN']
+BUCKET      = os.environ['TEST_S3_BUCKET']
+KEY         = os.environ['TEST_S3_KEY']
+SESSION     = 'migration-test-session'
+ 
+def build_upload_policy(bucket, key):
+    """Mirrors the policy built in external_creds() for upload=True."""
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Action": ["s3:GetObject", "s3:PutObject"],
+            "Resource": [f"arn:aws:s3:::{bucket}/{key}"],
+            "Effect": "Allow"
+        }, 
+        {
+            "Action": ["s3:ListBucket"],
+            "Resource": [f"arn:aws:s3:::{bucket}"],
+            "Condition": {"StringLike": {"s3:prefix": [key]}},
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        }
+        ]
+    }
+    return policy
+ 
+def test_get_scoped_credentials():
+    print('TEST 1: assume_role returns credentials...')
+    conn = boto3.client('sts')
+    token = conn.assume_role(
+        RoleArn=ROLE_ARN,
+        RoleSessionName=SESSION,
+        Policy=json.dumps(build_upload_policy(BUCKET, KEY))
+    )
+    creds = token['Credentials']
+    assert 'AccessKeyId' in creds
+    assert 'SecretAccessKey' in creds
+    assert 'SessionToken' in creds
+    assumed_user = token['AssumedRoleUser']
+    assert 'Arn' in assumed_user
+    assert 'AssumedRoleId' in assumed_user
+    print(f'  OK — expires {creds["Expiration"]}')
+    return creds
+def test_upload_works(creds):
+    print('TEST 2: scoped creds can upload to target key...')
+    s3 = boto3.client('s3',
+        aws_access_key_id=creds['AccessKeyId'],
+        aws_secret_access_key=creds['SecretAccessKey'],
+        aws_session_token=creds['SessionToken'])
+    s3.put_object(Bucket=BUCKET, Key=KEY, Body=b'migration test content')
+    print('  OK')
+    return s3
+def test_download_works(s3):
+    print('TEST 3: scoped creds can download target key...')
+    resp = s3.get_object(Bucket=BUCKET, Key=KEY)
+    assert resp['Body'].read() == b'migration test content'
+    print('  OK')
+def test_other_key_denied(creds):
+    print('TEST 4: scoped creds CANNOT access a different key (policy enforcement)...')
+    s3 = boto3.client('s3',
+        aws_access_key_id=creds['AccessKeyId'],
+        aws_secret_access_key=creds['SecretAccessKey'],
+        aws_session_token=creds['SessionToken'])
+    try:
+        s3.get_object(Bucket=BUCKET, Key='some/completely/different/key.txt')
+        print('  FAIL — should have been denied!')
+        sys.exit(1)
+    except s3.exceptions.ClientError as e:
+        assert e.response['Error']['Code'] in ('403', 'AccessDenied')
+        print('  OK — access correctly denied')
+def test_download_only_policy():
+    print('TEST 5: download-only policy (upload=False) denies PutObject...')
+    download_policy = {
+        "Version": "2012-10-17",
+        "Statement": [{"Action": ["s3:GetObject"],
+                       "Resource": [f"arn:aws:s3:::{BUCKET}/{KEY}"],
+                       "Effect": "Allow"}]
+    }
+    conn = boto3.client('sts')
+    token = conn.assume_role(
+        RoleArn=ROLE_ARN,
+        RoleSessionName=SESSION + '-dl',
+        Policy=json.dumps(download_policy)
+    )
+    creds = token['Credentials']
+    s3 = boto3.client('s3',
+        aws_access_key_id=creds['AccessKeyId'],
+        aws_secret_access_key=creds['SecretAccessKey'],
+        aws_session_token=creds['SessionToken'])
+    try:
+        s3.put_object(Bucket=BUCKET, Key=KEY, Body=b'should fail')
+        print('  FAIL — PutObject should have been denied!')
+        sys.exit(1)
+    except Exception:
+        print('  OK — PutObject correctly denied on download-only creds')
+if __name__ == '__main__':
+    creds = test_get_scoped_credentials()
+    s3    = test_upload_works(creds)
+    test_download_works(s3)
+    test_other_key_denied(creds)
+    test_download_only_policy()
+    print()
+    print('All tests passed. Ready to open PR.')

--- a/src/encoded_core/types/file.py
+++ b/src/encoded_core/types/file.py
@@ -131,12 +131,48 @@ def external_creds(bucket, key, name=None, profile_name=None, upload=True):
                     "Effect": "Allow"
                 })
         # In the new environment, extract S3 Keys from global application configuration
+        # #BEFORE
+        # if 'IDENTITY' in os.environ:
+        #     identity = assume_identity()
+        #     with override_environ(**identity):
+        #         conn = boto3.client('sts',
+        #                             aws_access_key_id=os.environ.get('S3_AWS_ACCESS_KEY_ID'),
+        #                             aws_secret_access_key=os.environ.get('S3_AWS_SECRET_ACCESS_KEY'))
+        #     s3_encrypt_key_id = identity.get('ENCODED_S3_ENCRYPT_KEY_ID')
+        #     if s3_encrypt_key_id:  # must be used with ACCOUNT_NUMBER as well
+        #         policy['Statement'].append({  # NoQA - PyCharm doesn't like this append for some bogus reason
+        #             'Effect': 'Allow',
+        #             'Action': [
+        #                 'kms:Encrypt',
+        #                 'kms:Decrypt',
+        #                 'kms:ReEncrypt*',
+        #                 'kms:GenerateDataKey*',
+        #                 'kms:DescribeKey'
+        #             ],
+        #             'Resource': f'arn:aws:kms:{CGAP_ECR_REGION}:{identity["ACCOUNT_NUMBER"]}:key/{s3_encrypt_key_id}'
+        #         })
+        # # In the old account, we are always passing IAM User creds so these will just work
+        # else:
+        #     conn = boto3.client('sts',
+        #                         aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
+        #                         aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'))
+        # token = conn.get_federation_token(Name=name, Policy=json.dumps(policy))
+        # # 'access_key' 'secret_key' 'expiration' 'session_token'
+        # credentials = token.get('Credentials')
+        # # Convert Expiration datetime object to string via cast
+        # # Uncaught serialization error picked up by Docker - Will 2/25/2021
+        # credentials['Expiration'] = str(credentials['Expiration'])
+        # credentials.update({
+        #     f'{upload_or_download}_url': f's3://{bucket}/{key}',
+        #     'federated_user_arn': token.get('FederatedUser').get('Arn'),
+        #     'federated_user_id': token.get('FederatedUser').get('FederatedUserId'),
+        #     's3_encrypt_key_id': s3_encrypt_key_id,
+        #     'request_id': token.get('ResponseMetadata').get('RequestId'),
+        #     'key': key
+        # })
+        #AFTER KELLY ROLE
         if 'IDENTITY' in os.environ:
             identity = assume_identity()
-            with override_environ(**identity):
-                conn = boto3.client('sts',
-                                    aws_access_key_id=os.environ.get('S3_AWS_ACCESS_KEY_ID'),
-                                    aws_secret_access_key=os.environ.get('S3_AWS_SECRET_ACCESS_KEY'))
             s3_encrypt_key_id = identity.get('ENCODED_S3_ENCRYPT_KEY_ID')
             if s3_encrypt_key_id:  # must be used with ACCOUNT_NUMBER as well
                 policy['Statement'].append({  # NoQA - PyCharm doesn't like this append for some bogus reason
@@ -150,12 +186,15 @@ def external_creds(bucket, key, name=None, profile_name=None, upload=True):
                     ],
                     'Resource': f'arn:aws:kms:{CGAP_ECR_REGION}:{identity["ACCOUNT_NUMBER"]}:key/{s3_encrypt_key_id}'
                 })
-        # In the old account, we are always passing IAM User creds so these will just work
+            role_arn = identity.get('S3_UPLOAD_ROLE_ARN')
         else:
-            conn = boto3.client('sts',
-                                aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
-                                aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'))
-        token = conn.get_federation_token(Name=name, Policy=json.dumps(policy))
+            role_arn = os.environ.get('S3_UPLOAD_ROLE_ARN')
+        conn = boto3.client('sts')
+        token = conn.assume_role(
+            RoleArn=role_arn,
+            RoleSessionName=name,
+            Policy=json.dumps(policy)
+        )
         # 'access_key' 'secret_key' 'expiration' 'session_token'
         credentials = token.get('Credentials')
         # Convert Expiration datetime object to string via cast
@@ -163,8 +202,8 @@ def external_creds(bucket, key, name=None, profile_name=None, upload=True):
         credentials['Expiration'] = str(credentials['Expiration'])
         credentials.update({
             f'{upload_or_download}_url': f's3://{bucket}/{key}',
-            'federated_user_arn': token.get('FederatedUser').get('Arn'),
-            'federated_user_id': token.get('FederatedUser').get('FederatedUserId'),
+            'federated_user_arn': token.get('AssumedRoleUser').get('Arn'),
+            'federated_user_id': token.get('AssumedRoleUser').get('AssumedRoleId'),
             's3_encrypt_key_id': s3_encrypt_key_id,
             'request_id': token.get('ResponseMetadata').get('RequestId'),
             'key': key


### PR DESCRIPTION
 **Background**
Previously, external_creds() used permanent IAM User access keys stored in Secrets Manager (S3_AWS_ACCESS_KEY_ID / S3_AWS_SECRET_ACCESS_KEY) to call sts:GetFederationToken and generate scoped temporary credentials for S3 file uploads and downloads. This required long-lived secrets to be maintained and rotated across multiple AWS accounts.
This change replaces that pattern with sts:AssumeRole, which works with the existing ECS Fargate Task Roles and eliminates the need for any permanent IAM User credentials.

 **Addressing the concern**

"You can't use a role to call get_federation_token"

Correct — but we don't need get_federation_token anymore. IAM Roles are already temporary. assume_role() does the same downscoping with the same inline Policy parameter and returns an identical Credentials object.

 **Code changes**

Remove explicit IAM User key construction from boto3 STS client
Replace get_federation_token(Name=...) with assume_role(RoleArn=..., RoleSessionName=...)
Update response handling: FederatedUser → AssumedRoleUser
New env var: S3_UPLOAD_ROLE_ARN (role ARN to assume — replaces key pair)
Read S3_UPLOAD_ROLE_ARN from GAC (Secrets Manager) or environment variable
All policy construction, KMS handling, and credential packaging unchanged

 **Infrastructure changes applied per AWS account**
Accounts: cgap-dbmi, 4dn, smaht-prod, smaht-wolf, cgap-mgb-prod, lzprod-cgap-production, cgap-dev-test

Created dedicated S3 Upload IAM Role (encoded-core-s3-upload) with scoped S3 and KMS permissions
Added ECS Task Roles to S3 Upload Role trust policy
Added sts:AssumeRole permission to ECS Task Roles targeting S3 Upload Role
Added S3_UPLOAD_ROLE_ARN to each account Secrets Manager secret

 **Testing**
Standalone test script included: src/encoded_core/tests/test_assume_role_migration.py

✅ assume_role() returns correct credentials shape
✅ Scoped credentials allow upload and download to target key only
✅ Cross-key access denied (policy enforcement confirmed)
✅ Download-only credentials correctly block PutObject
✅ KMS encrypted buckets work with KMS actions in session policy
✅ No regressions in existing test suite